### PR TITLE
feat(api): add streaming event download

### DIFF
--- a/DEVELOPMENT_QUERY_GUIDE.md
+++ b/DEVELOPMENT_QUERY_GUIDE.md
@@ -30,6 +30,7 @@ The API expects a JSON payload with the following fields:
 The API returns a JSON object with detailed information about the query execution.
 
 **Successful Response Structure:**
+
 - `results`: An array of JSON objects, where each object represents a row in the query result. The keys correspond to the column names in your `SELECT` statement.
 - `duration_ms`: Query execution time in milliseconds
 - `files`: Array of parquet file information that were accessed during the query
@@ -204,11 +205,13 @@ ORDER BY bucket, count DESC
 Returns system statistics and storage information.
 
 **Example Request:**
+
 ```bash
 curl http://localhost:8080/stats
 ```
 
 **Response:**
+
 ```json
 {
   "in_memory_events": 15234,
@@ -217,6 +220,15 @@ curl http://localhost:8080/stats
   "oldest_event": "2025-01-01T00:00:00Z",
   "newest_event": "2025-01-07T23:59:59Z"
 }
+```
+
+### Download Endpoint: `GET /download`
+
+Streams the result of a `WHERE` clause over a time range as gzipped JSON Lines ordered by `lastTimestamp`. The `where` clause you use in the query builder can be passed directly to this endpoint.
+
+```bash
+curl -L "http://localhost:8080/download?from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z&where=type%20=%20'Warning'" \
+  --output events.jsonl.gz
 ```
 
 ### Web Interface Routes

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Kabinet is a single-binary "event cabinet" for Kubernetes: it collects cluster events in real time, stores them efficiently (DuckDB + Parquet), and lets you explore them on demand with fast queries and dashboards.
 
-
 ## The Problem
 
 Monitoring Kubernetes events is crucial for maintaining cluster health. However, traditional methods often fall short:
@@ -142,10 +141,10 @@ graph LR
     ```bash
     # Build the frontend
     npm run build
-    
+
     # Build the Go binary (includes embedded frontend)
     go build -o kabinet main.go
-    
+
     # Run the production binary
     ./kabinet
     ```
@@ -238,6 +237,26 @@ The primary API endpoint accepts SQL queries with time range parameters. The `$e
   "total_files_size_bytes": 12345678
 }
 ```
+
+### Download Endpoint: `GET /download`
+
+Streams Kubernetes events that match a `WHERE` clause and time range as gzipped JSON Lines in chronological order.
+
+**Query Parameters:**
+
+- `from`: start time (RFC3339)
+- `to`: end time (RFC3339)
+- `where`: SQL `WHERE` clause applied to `$events`
+
+**Example:**
+
+```bash
+curl -L "http://localhost:8080/download?from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z&where=type%20=%20'Warning'" \
+  --output events.jsonl.gz
+```
+
+The response sets `Content-Type: application/jsonl` and `Content-Encoding: gzip`, and events are ordered by `lastTimestamp`.
+The Discover page includes a **Download** button that calls this endpoint with the current filters.
 
 ### Example: Top Event Reasons
 

--- a/internal/storage/events_query_test.go
+++ b/internal/storage/events_query_test.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildEventsQuery(t *testing.T) {
+	tmpDir := t.TempDir()
+	// create dummy parquet files
+	if err := os.WriteFile(filepath.Join(tmpDir, "events-0-100.parquet"), []byte{}, 0644); err != nil {
+		t.Fatalf("failed to create parquet file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "events-200-300.parquet"), []byte{}, 0644); err != nil {
+		t.Fatalf("failed to create parquet file: %v", err)
+	}
+
+	s := &Storage{dataDir: tmpDir}
+
+	start := time.Unix(50, 0).UTC()
+	end := time.Unix(150, 0).UTC()
+
+	q := "SELECT * FROM $events WHERE type = 'Warning' ORDER BY lastTimestamp"
+	final, files, err := s.buildEventsQuery(q, start, end)
+	if err != nil {
+		t.Fatalf("buildEventsQuery returned error: %v", err)
+	}
+
+	if !strings.Contains(final, "type = 'Warning'") {
+		t.Errorf("where clause missing in final query: %s", final)
+	}
+	if !strings.Contains(final, "ORDER BY lastTimestamp") {
+		t.Errorf("order by missing in final query: %s", final)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 relevant file, got %d", len(files))
+	}
+	if !strings.Contains(final, "events-0-100.parquet") {
+		t.Errorf("expected first parquet file in query, got %s", final)
+	}
+}

--- a/internal/storage/query.go
+++ b/internal/storage/query.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -17,70 +15,11 @@ func (s *Storage) RangeQuery(ctx context.Context, query string, start, end time.
 		return nil, nil, fmt.Errorf("failed fast: %w", ctx.Err())
 	}
 
-	files, err := os.ReadDir(s.dataDir)
+	finalQuery, files, err := s.buildEventsQuery(query, start, end)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read data directory: %w", err) // TODO: retry?
-	}
-	queryStartTs := start.Unix()
-	queryEndTs := end.Unix()
-
-	var relevantFiles []ParquetFileInfo
-	var latestParquetMaxTs int64
-
-	for _, file := range files {
-		if file.IsDir() || !strings.HasSuffix(file.Name(), ".parquet") {
-			continue
-		}
-
-		info, err := file.Info()
-		if err != nil {
-			log.Printf("storage: could not get file info for %s: %v", file.Name(), err)
-			continue
-		}
-
-		minTs, maxTs, ok := parseParquetFilename(file.Name())
-		if !ok {
-			log.Printf("storage: could not parse filename %s, including it just in case.", file.Name())
-			relevantFiles = append(relevantFiles, ParquetFileInfo{
-				Path: filepath.Join(s.dataDir, file.Name()),
-				Size: info.Size(),
-			})
-			continue
-		}
-
-		if maxTs > latestParquetMaxTs {
-			latestParquetMaxTs = maxTs
-		}
-
-		// File range overlaps with query range if:
-		// (file_start <= query_end) AND (file_end >= query_start)
-		if maxTs >= queryStartTs && minTs <= queryEndTs {
-			relevantFiles = append(relevantFiles, ParquetFileInfo{
-				Path: filepath.Join(s.dataDir, file.Name()),
-				Size: info.Size(),
-			})
-		}
+		return nil, nil, err
 	}
 
-	// Determine if we need to query the live kube_events table.
-	// If the user's query range ends before the last archived event, we can skip it.
-	includeKubeEvents := true
-	if latestParquetMaxTs > 0 && queryEndTs < latestParquetMaxTs {
-		includeKubeEvents = false
-	}
-
-	relevantFilePaths := make([]string, len(relevantFiles))
-	for i, f := range relevantFiles {
-		relevantFilePaths[i] = f.Path
-	}
-
-	fromClause, err := buildFromClause(relevantFilePaths, includeKubeEvents, start, end)
-	if err != nil {
-		log.Println("storage: query time range resulted in no data sources. returning empty result.")
-		return nil, nil, fmt.Errorf("query time range resulted in no data sources")
-	}
-
-	finalQuery := strings.Replace(query, "$events", fromClause, 1)
 	log.Printf("storage: executing range query: %s", finalQuery)
 
 	now := time.Now()
@@ -94,7 +33,7 @@ func (s *Storage) RangeQuery(ctx context.Context, query string, start, end time.
 	}
 	return results, &RangeQueryResult{
 		Duration: time.Since(now),
-		Files:    relevantFiles,
+		Files:    files,
 	}, nil
 }
 

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -8,6 +8,7 @@ import {
   alpha,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import { useTimeRange } from "../hooks/useUrlParams";
 
 interface QueryFormProps {
   whereClause: string;
@@ -29,10 +30,22 @@ const QueryForm: React.FC<QueryFormProps> = ({
   onExecuteQuery,
   isLoading,
 }) => {
+  const { from, to } = useTimeRange();
+
   const handleKeyPress = (event: React.KeyboardEvent) => {
     if (event.key === "Enter" && event.ctrlKey) {
       onExecuteQuery();
     }
+  };
+
+  const handleDownload = () => {
+    const trimmedWhere = whereClause.trim() || "1=1";
+    const params = new URLSearchParams({
+      where: trimmedWhere,
+      from,
+      to,
+    });
+    window.location.href = `/download?${params.toString()}`;
   };
 
   return (
@@ -126,6 +139,21 @@ const QueryForm: React.FC<QueryFormProps> = ({
           ) : (
             "Execute"
           )}
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={handleDownload}
+          size="large"
+          sx={{
+            minWidth: 120,
+            height: "fit-content",
+            px: 3,
+            py: 1.5,
+            borderRadius: 1.5,
+            fontWeight: 600,
+          }}
+        >
+          Download
         </Button>
       </QueryBox>
     </Box>


### PR DESCRIPTION
## Summary
- refactor storage to share event query construction and add row streaming
- add `/download` endpoint to stream gzipped JSON Lines with separate encoding and compression goroutines
- expose download button in the Discover page and document the endpoint

## Testing
- `npm run lint`
- `go test ./...` *(fails: pattern all:dist: no matching files found)*
- `go build -o main .` *(fails: pattern all:dist: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_6898af4f72008325a67bf2cf937dc8bd